### PR TITLE
Now that Guzzle7 is out use the guzzle7 adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,16 @@ PHP client for [Clockify.me API](https://clockify.me/developers-api).
 
 ## Install it
 
-Install using [composer](https://getcomposer.org):
+Install using [composer](https://getcomposer.org), with guzzle6-adapter:
 
 ```bash
 composer require jdecool/clockify-api php-http/guzzle6-adapter
+```
+
+Install using [composer](https://getcomposer.org), with guzzle7-adapter:
+
+```bash
+composer require jdecool/clockify-api php-http/guzzle7-adapter
 ```
 
 The library is decoupled from any HTTP message client with [HTTPlug](http://httplug.io). That's why you need to install a client implementation `http://httplug.io/` in this example.

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.15",
-        "php-http/guzzle6-adapter": "^2.0.1",
+        "php-http/guzzle7-adapter": "^0.1.0",
         "phpstan/phpstan": "^0.11.16",
         "phpunit/phpunit": "^8.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,6 @@
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.15",
-        "php-http/guzzle7-adapter": "^0.1.0",
         "phpstan/phpstan": "^0.11.16",
         "phpunit/phpunit": "^8.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.15",
+        "php-http/mock-client": "^1.4",
         "phpstan/phpstan": "^0.11.16",
         "phpunit/phpunit": "^8.0"
     },


### PR DESCRIPTION
I was getting errors trying to install this package with the Guzzle6 adapter, I was able to get everything working bu upgrading to Laravel 8 (and Guzzle 7). 

This PR just bumps the guzzle adapter to 7.

I was able to successfully get this working on a Laravel 8 package using the following command: 

```
composer require jdecool/clockify-api php-http/guzzle7-adapter
```